### PR TITLE
Add depenency curl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Sam McLeod
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install Debian packages
-RUN apt-get -y update && apt-get -y install openssh-client coreutils fakeroot build-essential kernel-package wget xz-utils gnupg bc devscripts apt-utils initramfs-tools aria2 && apt-get clean
+RUN apt-get -y update && apt-get -y install openssh-client coreutils fakeroot build-essential kernel-package wget xz-utils gnupg bc devscripts apt-utils initramfs-tools aria2 curl && apt-get clean
 RUN mkdir -p /mnt/storage
 
 WORKDIR /app


### PR DESCRIPTION
On my system when building in Docker, curl does not get installed and so the script tried to build a kernel of no version. This ensures curl gets installed and the script works (in Docker mode)
