### PR TITLE
Changes to make it more docker-friendly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+run.sh
+linux/
+*.tmp
+*.sign
+linux-4*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.swp
+*.sw?
 .tmp
 .deb
 .xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM debian:wheezy
+FROM debian:stretch
 MAINTAINER Sam McLeod
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install Debian packages
-RUN apt-get -y update && apt-get -y install openssh-client coreutils fakeroot build-essential kernel-package wget xz-utils gnupg bc devscripts apt-utils initramfs-tools aria2 curl && apt-get clean
-RUN mkdir -p /mnt/storage
-
-WORKDIR /app
+RUN apt-get -y update && \
+    apt-get -y install \
+      openssh-client coreutils fakeroot build-essential \
+      kernel-package wget xz-utils gnupg bc devscripts \
+      apt-utils initramfs-tools aria2 curl libssl-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD * /app/
-
-RUN chmod +x buildkernel.sh && ./buildkernel.sh
+WORKDIR /app
+ENTRYPOINT ["/app/buildkernel.sh"]


### PR DESCRIPTION
Several changes to `buildkernel.sh` aggregated in this PR/commit:

  * Don't run `buildkernel.sh` as part of image build.
  * Build on top of `stretch` as a workaround to the `Cannot use CONFIG_CC_STACKPROTECTOR_STRONG` error. 
  * Support bind-mounted source trees (by convention `/linux` folder), mainly to have persisting build artifacts.
  * Since we are now building as part of container execution (and not image build), we have to detect whether we run in a container by checking whether `/.dockerenv` exists (as opposed to `/.dockerinit`).
  * If running in a container, don't do `apt-get update`
  * fixes #25 
  * fixes #23 

I tested this with the following:

```
docker build -t kernel-ci .
docker run --rm -ti
    -v `pwd`/linux:/linux \
    -v `pwd`/patches:/app/patches \
   kernel-ci
```